### PR TITLE
Improve docker setup

### DIFF
--- a/Dockerfile.master
+++ b/Dockerfile.master
@@ -1,5 +1,10 @@
-FROM node
+# use alpine linux, it's much smaller (22MB vs 256MB)
+FROM node:8-alpine
+
 WORKDIR /usr/master
-ADD ./master .
-EXPOSE 8000
+
+COPY ./master/package.json .
+RUN npm i
+COPY ./master /usr/master
+
 CMD ["node", "master.js"]

--- a/Dockerfile.slave
+++ b/Dockerfile.slave
@@ -1,5 +1,10 @@
-FROM node
+# use alpine linux, it's much smaller (22MB vs 256MB)
+FROM node:8-alpine
+
 WORKDIR /usr/slave
-ADD ./slave .
-EXPOSE 8000
+
+COPY ./slave/package.json .
+RUN npm i
+COPY ./slave /usr/slave
+
 CMD ["node", "slave.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,20 @@
-master:
-  build: .
-  dockerfile: Dockerfile.master
-  volumes:
-    - ./master:/usr/master
-  expose:
-    - 8000
+version: '3'
 
-slave:
-  build: .
-  dockerfile: Dockerfile.slave
-  volumes:
-    - ./slave:/usr/slave
-  links:
-    - master:master
-  expose:
-    - 8000
+services:
+  master:
+    build:
+      context: .
+      dockerfile: Dockerfile.master
+    deploy:
+      mode: global # one per swarm
+    environment:
+      NODE_ENV: production # deploy in prod settings
+
+  slave:
+    build:
+      context: .
+      dockerfile: Dockerfile.slave
+    deploy:
+      replicas: 6
+    environment:
+      NODE_ENV: production

--- a/master/master.js
+++ b/master/master.js
@@ -17,16 +17,20 @@ ipc.server.start()
 
 // Testing (run after 10 seconds)
 setInterval(function () {
-	if (slaves.length == 0) {
-		throw "No connected slaves"
-	} else {
-		if (slave_n >= slaves.length) slave_n = 0
-		console.log('sending calculation to slave')
-		ipc.server.emit(slaves[slave_n], 'run calculation', {
-			operation: 'multiply',
-			n1: 5,
-			n2: 7
-		})
-		slave_n += 1
-	}
+	if (slaves.length == 0) return console.log("No connected slaves")
+
+	if (slave_n >= slaves.length) slave_n = 0
+
+	console.log('sending calculation to slave')
+	ipc.server.emit(slaves[slave_n], 'run calculation', {
+		operation: 'multiply',
+		n1: 5,
+		n2: 7
+	})
+	slave_n += 1
 }, 1 * 1000)
+
+process.on('SIGINT', () => {
+	// let docker exit gracefully
+  process.exit(0)
+})

--- a/master/package.json
+++ b/master/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "master.js",
   "scripts": {
-    "test": "node master.js"
+    "start": "node master.js"
   },
   "author": "Oli Callaghan",
   "license": "MIT",

--- a/slave/package.json
+++ b/slave/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "slave.js",
   "scripts": {
-    "test": "node slave.js"
+    "start": "node slave.js"
   },
   "author": "Oli Callaghan",
   "license": "MIT",

--- a/slave/slave.js
+++ b/slave/slave.js
@@ -16,3 +16,8 @@ ipc.connectToNet('namespace', 'master', 8000, function () {
 		console.log(data.n1, data.operation, data.n2, '=', ans)
 	})
 })
+
+process.on('SIGINT', () => {
+	// let docker exit gracefully
+  process.exit(0)
+})


### PR DESCRIPTION
- switch to alpine base for node, it’s much smaller (22MB vs 265MB)
- clean up compose file & switch node to production mode (saves on `npm
i` & tells packages to use prod settings)
- tell node processes to exit when docker tells them to
- switch `npm test` -> `npm start`